### PR TITLE
Switch docs and README branding to ly.sa

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-<p align="center"><a href="https://kutt.it" title="kutt.it"><img src="https://raw.githubusercontent.com/thedevs-network/kutt/9d1c873897c3f5b9a1bd0c74dc5d23f2ed01f2ec/static/images/logo-github.png" alt="Kutt.it"></a></p>
+<p align="center"><a href="https://ly.sa" title="ly.sa"><img src="https://raw.githubusercontent.com/thedevs-network/kutt/9d1c873897c3f5b9a1bd0c74dc5d23f2ed01f2ec/static/images/logo-github.png" alt="Ly.sa"></a></p>
 
-# Kutt.it
+# Ly.sa
 
-**Kutt** is a modern URL shortener with support for custom domains. Create and edit links, view statistics, manage users, and more.
+**Ly.sa** is a modern URL shortener with support for custom domains. Create and edit links, view statistics, manage users, and more.
 
-[https://kutt.it](https://kutt.it)
+[https://ly.sa](https://ly.sa)
 
 
 [![docker-build-release](https://github.com/thedevs-network/kutt/actions/workflows/docker-build-release.yaml/badge.svg)](https://github.com/thedevs-network/kutt/actions/workflows/docker-build-release.yaml)
-[![Uptime Status](https://uptime.betterstack.com/status-badges/v2/monitor/1ogaa.svg)](https://status.kutt.it)
+[![Uptime Status](https://uptime.betterstack.com/status-badges/v2/monitor/1ogaa.svg)](https://status.ly.sa)
 [![Contributions](https://img.shields.io/badge/contributions-welcome-brightgreen.svg)](https://github.com/thedevs-network/kutt/#contributing)
 [![GitHub license](https://img.shields.io/github/license/thedevs-network/kutt.svg)](https://github.com/thedevs-network/kutt/blob/develop/LICENSE)
 
@@ -43,9 +43,9 @@
 
 ## Donations and sponsors
 
-Support the development of Kutt by making a donation or becoming an sponsor.
+Support the development of Ly.sa by making a donation or becoming an sponsor.
 
-[Donate or sponsor →](https://btcpay.kutt.it/apps/L9Gc7PrnLykeRHkhsH2jHivBeEh/crowdfund)
+[Donate or sponsor →](https://btcpay.ly.sa/apps/L9Gc7PrnLykeRHkhsH2jHivBeEh/crowdfund)
 
 ## Setup
 
@@ -68,19 +68,19 @@ docker compose up
 
 Various docker-compose configurations are available. Use `docker compose -f <file_name> up` to start the one you want:
 
-- [`docker-compose.yml`](./docker-compose.yml): Default Kutt setup. Uses SQLite for the database.
-- [`docker-compose.sqlite-redis.yml`](./docker-compose.sqlite-redis.yml): Starts Kutt with SQLite and Redis.
+- [`docker-compose.yml`](./docker-compose.yml): Default Ly.sa setup. Uses SQLite for the database.
+- [`docker-compose.sqlite-redis.yml`](./docker-compose.sqlite-redis.yml): Starts Ly.sa with SQLite and Redis.
   - Required environment variable: `REDIS_ENABLED`
-- [`docker-compose.postgres.yml`](./docker-compose.postgres.yml): Starts Kutt with Postgres and Redis.
+- [`docker-compose.postgres.yml`](./docker-compose.postgres.yml): Starts Ly.sa with Postgres and Redis.
   - Required environment variables: `REDIS_ENABLED`, `DB_PASSWORD`, `DB_NAME`, `DB_USER`
-- [`docker-compose.mariadb.yml`](./docker-compose.mariadb.yml): Starts Kutt with MariaDB and Redis.
+- [`docker-compose.mariadb.yml`](./docker-compose.mariadb.yml): Starts Ly.sa with MariaDB and Redis.
   - Required environment variables: `REDIS_ENABLED`, `DB_PASSWORD`, `DB_NAME`, `DB_USER`, `DB_PORT`
 
-Official Kutt Docker image is available on [Docker Hub](https://hub.docker.com/r/kutt/kutt).
+Official Ly.sa Docker image is available on [Docker Hub](https://hub.docker.com/r/lysa/lysa).
 
 ## API
 
-[View API documentation →](https://docs.kutt.it)
+[View API documentation →](https://docs.ly.sa)
 
 ## Configuration
 
@@ -94,7 +94,7 @@ You can use files for each of the variables by appending `_FILE` to the name of 
 | -------- | ----------- | ------- | ------- |
 | `JWT_SECRET` | This is used to sign authentication tokens. Use a **long** **random** string. | - | - |
 | `PORT` |  The port to start the app on | `3000` | `8888` |
-| `SITE_NAME` |  Name of the website | `Kutt` | `Your Site` |
+| `SITE_NAME` |  Name of the website | `Ly.sa` | `Your Site` |
 | `DEFAULT_DOMAIN` |  The domain address that this app runs on | `localhost:3000` | `yoursite.com` |
 | `LINK_LENGTH` | The length of of shortened address | `6` | `5` |
 | `LINK_CUSTOM_ALPHABET` | Alphabet used to generate custom addresses. Default value omits o, O, 0, i, I, l, 1, and j to avoid confusion when reading the URL. | (abcd..789) | `abcABC^&*()@` |
@@ -105,7 +105,7 @@ You can use files for each of the variables by appending `_FILE` to the name of 
 | `DB_FILENAME` |  File path for the SQLite database. Only if you use SQLite. | `db/data` | `/var/lib/data` |
 | `DB_HOST` | Database connection host. Only if you use Postgres or MySQL. | `localhost` | `your-db-host.com` |
 | `DB_PORT` | Database port. Only if you use Postgres or MySQL. | `5432` (Postgres) | `3306` (MySQL) |
-| `DB_NAME` | Database name. Only if you use Postgres or MySQL. | `kutt` | `mydb` |
+| `DB_NAME` | Database name. Only if you use Postgres or MySQL. | `lysa` | `mydb` |
 | `DB_USER` | Database user. Only if you use Postgres or MySQL. | `postgres` | `myuser` |
 | `DB_PASSWORD` | Database password. Only if you use Postgres or MySQL. | - | `mypassword` |
 | `DB_SSL` | Whether use SSL for the database connection. Only if you use Postgres or MySQL. | `false` | `true` |
@@ -157,14 +157,14 @@ custom/
 
 - **css**: Put your CSS style files here. ([View example →](https://github.com/thedevs-network/kutt-customizations/tree/main/themes/crimson/css))
   - You can put as many style files as you want: `custom1.css`, `custom2.css`, etc.
-  - If you name your style file `styles.css`, it will replace Kutt's original `styles.css` file.
+  - If you name your style file `styles.css`, it will replace Ly.sa's original `styles.css` file.
   - Each file will be accessible by `<your-site.com>/css/<file>.css`
 - **images**: Put your images here. ([View example →](https://github.com/thedevs-network/kutt-customizations/tree/main/themes/crimson/images))
-  - Name them just like the files inside the [`/static/images/`](./static/images) folder to replace Kutt's original images.
+  - Name them just like the files inside the [`/static/images/`](./static/images) folder to replace Ly.sa's original images.
   - Each image will be accessible by `<your-site.com>/images/<image>.<image-format>`
 - **views**: Custom HTML templates to render. ([View example →](https://github.com/thedevs-network/kutt-customizations/tree/main/themes/crimson/views))
   - It should follow the same file naming and folder structure as [`/server/views`](./server/views)
-  - Although we try to keep the original file names unchanged, be aware that new changes on Kutt might break your custom views.
+  - Although we try to keep the original file names unchanged, be aware that new changes on Ly.sa might break your custom views.
  
 #### Example theme: Crimson
 
@@ -183,25 +183,25 @@ This is an example and official theme. Crimson includes custom styles, images, a
 
 If you're building the image locally, then the `/custom` folder should already be included in your app.
 
-If you're pulling the official image, make sure `/kutt/custom` volume is mounted or you have access to it. [View Docker compose example →](https://github.com/thedevs-network/kutt/blob/main/docker-compose.yml#L7)
+If you're pulling the official image, make sure `/lysa/custom` volume is mounted or you have access to it. [View Docker compose example →](https://github.com/thedevs-network/kutt/blob/main/docker-compose.yml#L7)
 
 Then, move your files to that volume. You can do it with this Docker command:
 
 ```sh
-docker cp <path-to-custom-folder> <kutt-container-name>:/kutt
+docker cp <path-to-custom-folder> <lysa-container-name>:/lysa
 ```
 
 For example:
 
 ```sh
-docker cp custom kutt-server-1:/kutt
+docker cp custom lysa-server-1:/lysa
 ```
 
-Make sure to restart the kutt server container after copying files or making changes.
+Make sure to restart the lysa server container after copying files or making changes.
 
 ## Browser extensions
 
-Download Kutt's extension for web browsers via below links.
+Download Ly.sa's extension for web browsers via below links.
 
 - [Chrome](https://chrome.google.com/webstore/detail/kutt/pklakpjfiegjacoppcodencchehlfnpd)
 - [Firefox](https://addons.mozilla.org/en-US/firefox/addon/kutt/)
@@ -214,28 +214,28 @@ Download Kutt's extension for web browsers via below links.
 
 ## Integrations
 
-- **ShareX** – You can use Kutt as your default URL shortener in [ShareX](https://getsharex.com/). If you host your custom instance of Kutt, refer to [ShareX wiki](https://github.com/thedevs-network/kutt/wiki/ShareX) on how to setup.
-- **Alfred workflow** – Download Kutt's official workflow for [Alfred](https://www.alfredapp.com/) app from [alfred-kutt](https://github.com/thedevs-network/alfred-kutt) repository.
-- **iOS shortcut** – [Kutt shortcut](https://www.icloud.com/shortcuts/a829856aea2c420e97c53437e68b752b) for your apple device which works from the iOS sharing context menu or on standalone mode. A courtesy of [@caneeeeee](https://github.com/caneeeeee).
+- **ShareX** – You can use Ly.sa as your default URL shortener in [ShareX](https://getsharex.com/). If you host your custom instance of Ly.sa, refer to [ShareX wiki](https://github.com/thedevs-network/kutt/wiki/ShareX) on how to setup.
+- **Alfred workflow** – Download Ly.sa's official workflow for [Alfred](https://www.alfredapp.com/) app from [alfred-kutt](https://github.com/thedevs-network/alfred-kutt) repository.
+- **iOS shortcut** – [Ly.sa shortcut](https://www.icloud.com/shortcuts/a829856aea2c420e97c53437e68b752b) for your apple device which works from the iOS sharing context menu or on standalone mode. A courtesy of [@caneeeeee](https://github.com/caneeeeee).
 
 **Third-party packages**
 
 
 | Language        | Link                                                                              | Description                                          |
 | --------------- | --------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| C# (.NET)       | [KuttSharp](https://github.com/0xaryan/KuttSharp)                                 | .NET package for Kutt.it url shortener               |
-| C# (.NET)       | [Kutt.NET](https://github.com/AlphaNecron/Kutt.NET)                               | C# API Wrapper for Kutt                              |
-| Python          | [kutt-cli](https://github.com/RealAmirali/kutt-cli)                               | Command-line client for Kutt written in Python       |
-| Ruby            | [kutt.rb](https://github.com/RealAmirali/kutt.rb)                                 | Kutt library written in Ruby                         |
+| C# (.NET)       | [KuttSharp](https://github.com/0xaryan/KuttSharp)                                 | .NET package for Ly.sa url shortener               |
+| C# (.NET)       | [Kutt.NET](https://github.com/AlphaNecron/Kutt.NET)                               | C# API Wrapper for Ly.sa                              |
+| Python          | [kutt-cli](https://github.com/RealAmirali/kutt-cli)                               | Command-line client for Ly.sa written in Python       |
+| Ruby            | [kutt.rb](https://github.com/RealAmirali/kutt.rb)                                 | Ly.sa library written in Ruby                         |
 | Rust            | [urlshortener](https://github.com/vityafx/urlshortener-rs)                        | URL shortener library written in Rust                |
 | Rust            | [kutt-rs](https://github.com/robatipoor/kutt-rs)                                  | Command line tool written in Rust                    |
-| Node.js         | [node-kutt](https://github.com/ardalanamini/node-kutt)                            | Node.js client for Kutt.it url shortener             |
-| JavaScript      | [kutt-vscode](https://github.com/mehrad77/kutt-vscode)                            | Visual Studio Code extension for Kutt                |
-| Java            | [kutt-desktop](https://github.com/cipher812/kutt-desktop)                         | A Cross platform Java desktop application for Kutt   |
-| Go              | [kutt-go](https://github.com/raahii/kutt-go)                                      | Go client for Kutt.it url shortener                  |
+| Node.js         | [node-kutt](https://github.com/ardalanamini/node-kutt)                            | Node.js client for Ly.sa url shortener             |
+| JavaScript      | [kutt-vscode](https://github.com/mehrad77/kutt-vscode)                            | Visual Studio Code extension for Ly.sa                |
+| Java            | [kutt-desktop](https://github.com/cipher812/kutt-desktop)                         | A Cross platform Java desktop application for Ly.sa   |
+| Go              | [kutt-go](https://github.com/raahii/kutt-go)                                      | Go client for Ly.sa url shortener                  |
 | BASH            | [GitHub Gist](https://gist.github.com/hashworks/6d6e4eae8984a5018f7692a796d570b4) | Simple BASH function to access the API               |
 | BASH            | [url-shortener](https://git.tim-peters.org/Tim/url-shortener)                     | Simple BASH script with GUI                          |
-| Kubernetes/Helm | [ArtifactHub](https://artifacthub.io/packages/helm/christianhuth/kutt)            | A Helm Chart to install Kutt on a Kubernetes cluster |
+| Kubernetes/Helm | [ArtifactHub](https://artifacthub.io/packages/helm/christianhuth/kutt)            | A Helm Chart to install Ly.sa on a Kubernetes cluster |
 
 ## Contributing
 

--- a/docs/api/api.js
+++ b/docs/api/api.js
@@ -4,13 +4,13 @@ const p = require("../../package.json");
 module.exports = {
   openapi: "3.0.0",
   info: {
-    title: "Kutt.it",
-    description: "API reference for [http://kutt.it](http://kutt.it).\n",
+    title: "Ly.sa",
+    description: "API reference for [http://ly.sa](http://ly.sa).\n",
     version: p.version
   },
   servers: [
     {
-      url: "https://kutt.it/api/v2"
+      url: "https://ly.sa/api/v2"
     }
   ],
   tags: [


### PR DESCRIPTION
## Summary
- update the API documentation title and server to ly.sa
- rename Kutt references in README to Ly.sa and update links

## Testing
- `npm run docs:build` *(fails: Cannot find module 'redoc')*